### PR TITLE
Add license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Dylan On
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/test_sites/gatsby_v2/package.json
+++ b/test_sites/gatsby_v2/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "gatsby": "^2.0.0",
-    "gatsby-source-etsy": "^1.0.0",
+    "gatsby-source-etsy": "^1.2.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   }

--- a/test_sites/gatsby_v2/yarn.lock
+++ b/test_sites/gatsby_v2/yarn.lock
@@ -5454,10 +5454,10 @@ gatsby-recipes@^0.9.3:
     xstate "^4.9.1"
     yoga-layout-prebuilt "^1.9.6"
 
-gatsby-source-etsy@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gatsby-source-etsy/-/gatsby-source-etsy-1.0.0.tgz#ea4a36a9c5a856b8dece969aaaeab693c2b2a0d4"
-  integrity sha512-BUmWzKDYaDNuRPrcNKIoOGf7z8wgNYOQnhTHflXN2JuKwZZ1il+vBTQC9eiQRb7E3ypjq8JlkNDX2OpPPYUmAA==
+gatsby-source-etsy@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gatsby-source-etsy/-/gatsby-source-etsy-1.2.0.tgz#9e1017f3f04444ecf2a49a631cc2d6a37227fc50"
+  integrity sha512-x+I9LO4WPCEdXmUHUxkQeB3vLvmFOs52RlnSxUCwgoqfJxOM8qnryEeFkY8z0flLkKz8eF41K3z7i4eQsngSmw==
   dependencies:
     bottleneck "^2.19.5"
     gatsby-source-filesystem "^2.1.5"


### PR DESCRIPTION
Note: This package has always been MIT licensed (see package.json). Adding for discoverability and clarity.